### PR TITLE
Bump NamelessMC version to pr8

### DIFF
--- a/upload/modules/CraftingStore/module.php
+++ b/upload/modules/CraftingStore/module.php
@@ -59,7 +59,7 @@ class CraftingStoreModule extends Module
         $name = 'CraftingStore';
         $author = 'CraftingStore';
         $moduleVersion = '0.1';
-        $namelessVersion = '2.0.0-pr7';
+        $namelessVersion = '2.0.0-pr8';
 
         parent::__construct($this, $name, $author, $moduleVersion, $namelessVersion);
 

--- a/upload/modules/CraftingStore/module.php
+++ b/upload/modules/CraftingStore/module.php
@@ -58,7 +58,7 @@ class CraftingStoreModule extends Module
 
         $name = 'CraftingStore';
         $author = 'CraftingStore';
-        $moduleVersion = '0.1';
+        $moduleVersion = '1.0';
         $namelessVersion = '2.0.0-pr8';
 
         parent::__construct($this, $name, $author, $moduleVersion, $namelessVersion);


### PR DESCRIPTION
Small PR to bump the NamelessMC version to pre-release 8- all seems to work fine with no further modifications needed

Also updated the module version to 1.0 to match the [latest release](https://github.com/CraftingStore/NamelessMC-CraftingStore/releases/tag/1.0)