### PR TITLE
Fixed error when success or error message variables are not countable

### DIFF
--- a/upload/custom/panel_templates/Default/craftingstore/sync.tpl
+++ b/upload/custom/panel_templates/Default/craftingstore/sync.tpl
@@ -34,30 +34,38 @@
 
                     <div class="card">
                         <div class="card-body">
-                            {if isset($SUCCESS) && count($SUCCESS)}
+                            {if isset($SUCCESS)}
                                 <div class="alert alert-success alert-dismissible">
                                     <button type="button" class="close" data-dismiss="alert" aria-label="Close">
                                         <span aria-hidden="true">&times;</span>
                                     </button>
                                     <h5><i class="icon fas fa-check"></i> {$SUCCESS_TITLE}</h5>
                                     <ul>
-                                        {foreach from=$SUCCESS item=item}
-                                            <li>{$item}</li>
-                                        {/foreach}
+                                        {if is_array($SUCCESS)}
+                                            {foreach from=$SUCCESS item=item}
+                                                <li>{$item}</li>
+                                            {/foreach}
+                                        {else}
+                                            <li>{$SUCCESS}</li>
+                                        {/if}
                                     </ul>
                                 </div>
                             {/if}
 
-                            {if isset($ERRORS) && count($ERRORS)}
+                            {if isset($ERRORS)}
                                 <div class="alert alert-danger alert-dismissible">
                                     <button type="button" class="close" data-dismiss="alert" aria-label="Close">
                                         <span aria-hidden="true">&times;</span>
                                     </button>
                                     <h5><i class="icon fas fa-exclamation-triangle"></i> {$ERRORS_TITLE}</h5>
                                     <ul>
-                                        {foreach from=$ERRORS item=error}
-                                            <li>{$error}</li>
-                                        {/foreach}
+                                        {if is_array($ERRORS)}
+                                            {foreach from=$ERRORS item=error}
+                                                <li>{$error}</li>
+                                            {/foreach}
+                                        {else}
+                                            <li>{$ERRORS}</li>
+                                        {/if}
                                     </ul>
                                 </div>
                             {/if}

--- a/upload/modules/CraftingStore/module.php
+++ b/upload/modules/CraftingStore/module.php
@@ -30,8 +30,8 @@ class CraftingStoreModule extends Module
 
         $name = 'CraftingStore';
         $author = 'CraftingStore';
-        $moduleVersion = '1.14';
-        $namelessVersion = '2.1.0';
+        $moduleVersion = '1.15';
+        $namelessVersion = '2.1.1';
 
         parent::__construct($this, $name, $author, $moduleVersion, $namelessVersion);
 


### PR DESCRIPTION
Resolves the following error: 
```
count(): Argument #1 ($value) must be of type Countable|array, string given
```